### PR TITLE
Make pi-hole reload lists after update

### DIFF
--- a/scripts/referral.sh
+++ b/scripts/referral.sh
@@ -27,8 +27,8 @@ sleep 0.5
 echo -e " ${TICK} \e[32m Removing duplicates... \e[0m"
 sudo gawk -i inplace '!a[$0]++' /etc/pihole/whitelist.txt
 wait
-echo -e " ${TICK} \e[32m Restarting DNS service \e[0m"
-pihole restartdns > /dev/null
+echo -e " ${TICK} \e[32m Pi-hole gravity rebuilding lists... \e[0m"
+pihole -g > /dev/null
 wait
 echo -e " ${TICK} \e[32m Done! \e[0m"
 

--- a/scripts/whitelist.sh
+++ b/scripts/whitelist.sh
@@ -27,8 +27,8 @@ sleep 0.5
 echo -e " ${TICK} \e[32m Removing duplicates... \e[0m"
 sudo gawk -i inplace '!a[$0]++' /etc/pihole/whitelist.txt
 wait
-echo -e " ${TICK} \e[32m Restarting DNS service \e[0m"
-pihole restartdns > /dev/null
+echo -e " ${TICK} \e[32m Pi-hole gravity rebuilding lists... \e[0m"
+pihole -g
 wait
 echo -e " ${TICK} \e[32m Done! \e[0m"
 

--- a/scripts/whitelist.sh
+++ b/scripts/whitelist.sh
@@ -28,7 +28,7 @@ echo -e " ${TICK} \e[32m Removing duplicates... \e[0m"
 sudo gawk -i inplace '!a[$0]++' /etc/pihole/whitelist.txt
 wait
 echo -e " ${TICK} \e[32m Pi-hole gravity rebuilding lists... \e[0m"
-pihole -g
+pihole -g > /dev/null
 wait
 echo -e " ${TICK} \e[32m Done! \e[0m"
 


### PR DESCRIPTION
This calls "pihole -g" to force pihole to run gravity, which rebuilds the list of blocked domains.
(Replaces call to "pihole restartdns" which does not reload altered lists).

See pi-hole/pi-hole Issue# 2188 
