### PR TITLE
sqs.us-east-1.amazonaws.com

### DIFF
--- a/domains/optional-list.txt
+++ b/domains/optional-list.txt
@@ -147,3 +147,6 @@ zeustracker.abuse.ch
 # https://github.com/anudeepND/whitelist/issues/30
 
 track.ucas.com
+
+# Amazon AWS (???) - whitelist to make Kryptonite work
+sqs.us-east-1.amazonaws.com


### PR DESCRIPTION
This domain is required to make Kryptonite authentication work. Since not everyone uses Kryptonite as an SSH private keyholder, this domain should be considered optional. If you block this doamin, the computer-to-phone communication will not function and therefore cause a timeout.