### PR TITLE
Fix script to run on Arch Linux and Fedora

### DIFF
--- a/scripts/whitelist.sh
+++ b/scripts/whitelist.sh
@@ -18,7 +18,13 @@ fi
 
 if ! (which gawk > /dev/null); then
   echo -e " [...] \e[32m Installing gawk... \e[0m"
-  apt-get install gawk -qq > /dev/null
+  if (which apt-get > /dev/null); then
+       apt-get install gawk -qq > /dev/null
+  elif (which pacman > /dev/null); then
+       pacman -Sqy gawk > /dev/null
+  elif (which dnf > /dev/null); then
+       dnf install gawk > /dev/null
+  fi
   wait
   echo -e " ${TICK} \e[32m Finished \e[0m"
 fi

--- a/scripts/whitelist.sh
+++ b/scripts/whitelist.sh
@@ -16,14 +16,12 @@ if [ "$(id -u)" != "0" ] ; then
 	exit 2
 fi
 
-if [ "$(dpkg-query -W -f='${Status}' gawk 2>/dev/null |  grep -c "ok installed")" -eq 0 ];
-then
+if ! (which gawk > /dev/null); then
   echo -e " [...] \e[32m Installing gawk... \e[0m"
   apt-get install gawk -qq > /dev/null
   wait
   echo -e " ${TICK} \e[32m Finished \e[0m"
 fi
-
 
 curl -sS https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt | sudo tee -a /etc/pihole/whitelist.txt >/dev/null
 echo -e " ${TICK} \e[32m Adding to whitelist... \e[0m"


### PR DESCRIPTION
Although PiHole isn't officially supported on distros other than Ubuntu/Debian, some people (like myself), will run it on other distributions.  This patch will use `which` to locate `gawk` in `$PATH` instead of relying on `dpkg`; if not found, it'll attempt to either use, `apt-get`, `pacman` or `dnf` to install it, whichever it finds first.