### PR TITLE
Add config for docker/non-standard installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ sudo chmod +x referral.sh
 sudo ./referral.sh
 ```
 
+***For non-standard Pi-Hole installations e.g. Docker***
+Create a `config.cfg` file in the `whitelist/scripts` with the following variables ammended to your installation:
+```
+PIHOLE_LOCATION="/home/pi/pihole"
+DOCKER_EXEC="docker exec -i -t pihole bash "
+``` 
+
 **Note: You don't have to clone the repo every time you need to update whitelist file. Navigate to `whitelist/scripts` and run it again `sudo ./referral.sh`**
         
 ***For optional-list.txt***     

--- a/scripts/referral.sh
+++ b/scripts/referral.sh
@@ -5,7 +5,12 @@
 # Created by Anudeep
 #================================================================================
 TICK="[\e[32m ✔ \e[0m]"
+PIHOLE_LOCATION="/etc/pihole"
 
+if [ -r config.cfg ]; then
+  echo "Reading user config...." >&2
+  source config.cfg
+fi
 
 echo -e " \e[1m This script will download and add domains from the repo to whitelist.txt \e[0m"
 sleep 1
@@ -32,7 +37,7 @@ echo -e " ${TICK} \e[32m Removing duplicates... \e[0m"
 gawk -i inplace '!a[$0]++' /etc/pihole/whitelist.txt
 wait
 echo -e " [...] \e[32m Pi-hole gravity rebuilding lists...This may take a while \e[0m"
-pihole -g > /dev/null
+"${DOCKER_EXEC}" pihole -g > /dev/null
 wait
 echo -e " ${TICK} \e[32m Pi-hole's gravity updated \e[0m"
 echo -e " ${TICK} \e[32m Done! \e[0m"

--- a/scripts/whitelist.sh
+++ b/scripts/whitelist.sh
@@ -5,7 +5,12 @@
 # Created by Anudeep
 #================================================================================
 TICK="[\e[32m ✔ \e[0m]"
+PIHOLE_LOCATION="/etc/pihole"
 
+if [ -r config.cfg ]; then
+  echo "Reading user config...." >&2
+  source config.cfg
+fi
 
 echo -e " \e[1m This script will download and add domains from the repo to whitelist.txt \e[0m"
 sleep 1
@@ -29,14 +34,14 @@ if ! (which gawk > /dev/null); then
   echo -e " ${TICK} \e[32m Finished \e[0m"
 fi
 
-curl -sS https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt | sudo tee -a /etc/pihole/whitelist.txt >/dev/null
+curl -sS https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt | sudo tee -a ${PIHOLE_LOCATION}/whitelist.txt >/dev/null
 echo -e " ${TICK} \e[32m Adding to whitelist... \e[0m"
 sleep 0.5
 echo -e " ${TICK} \e[32m Removing duplicates... \e[0m"
-sudo gawk -i inplace '!a[$0]++' /etc/pihole/whitelist.txt
+sudo gawk -i inplace '!a[$0]++' "${PIHOLE_LOCATION}"/whitelist.txt
 wait
 echo -e " [...] \e[32m Pi-hole gravity rebuilding lists. This may take a while... \e[0m"
-pihole -g > /dev/null
+${DOCKER_EXEC} pihole -g > /dev/null
 wait
 echo -e " ${TICK} \e[32m Pi-hole's gravity updated \e[0m"
 echo -e " ${TICK} \e[32m Done! \e[0m"


### PR DESCRIPTION
For installations like docker the current scripts won't work without editing the hardcoded paths to the Pi-Hole config folder.
I have added an optional config file that can source the folder path as well as a command to run gravity by prefixing a suitable `docker exec` command.

It's ugly and could probably be replaced by calling gravity update via `curl` but everyone might not have `curl` installed.