### PR TITLE
whitelist storage.googleapis.com

### DIFF
--- a/domains/whitelist.txt
+++ b/domains/whitelist.txt
@@ -214,3 +214,5 @@ www.synology.com
 synology.com
 instantmessaging-pa.googleapis.com
 feeds.feedburner.com
+storage.googleapis.com
+www.storage.googleapis.com


### PR DESCRIPTION
This domain is used by some iPhone apps like SCENE.

The following lists block this domain:

https://tspprs.com/dl/malware
https://tspprs.com/dl/phishing