### PR TITLE
Add static.tp-link.com

### DIFF
--- a/domains/whitelist.txt
+++ b/domains/whitelist.txt
@@ -215,3 +215,4 @@ synology.com
 instantmessaging-pa.googleapis.com
 feeds.feedburner.com
 res.cloudinary.com
+static.tp-link.com


### PR DESCRIPTION
@anudeepND static.tp-link.com is used for images on tp-link.com
Match found in https://tspprs.com/dl/cl1:
   static.tp-link.com