### PR TITLE
Add fontawesome cdn domains to whitelist. Solves #59

### DIFF
--- a/domains/whitelist.txt
+++ b/domains/whitelist.txt
@@ -215,3 +215,5 @@ synology.com
 instantmessaging-pa.googleapis.com
 feeds.feedburner.com
 res.cloudinary.com
+pro.fontawesome.com
+use.fontawesome.com


### PR DESCRIPTION
I don't see any reason for not adding fontawesome cdn domains to the list.

`pro.fontawesome.com`
`use.fontawesome.com`