### PR TITLE
Add samsung cloud solution cdn

### DIFF
--- a/domains/whitelist.txt
+++ b/domains/whitelist.txt
@@ -25,6 +25,7 @@ c.s-microsoft.com
 cdn.cloudflare.net
 cdn.embedly.com
 cdn.optimizely.com
+cdn.samsungcloudsolution.com
 cdn.vidible.tv
 cdn2.optimizely.com
 cdn3.optimizely.com


### PR DESCRIPTION
Fixes #80 by adding `cdn.samsungcloudsolution.com`

not sure if this should be in whitelist or in optional but for now i put it in whitelist