### PR TITLE
Add petri.com

### DIFF
--- a/domains/whitelist.txt
+++ b/domains/whitelist.txt
@@ -129,6 +129,7 @@ om.cbsi.com
 onedrive.live.com
 outlook.live.com
 outlook.office365.com
+petri.com
 pinterest.com
 placehold.it
 placeholdit.imgix.net


### PR DESCRIPTION
Match found in https://v.firebog.net/hosts/Airelle-trc.txt:
www.petri.com

Petri.com is a known IT knowledgebase