### PR TITLE
add sony.co.uk

### DIFF
--- a/domains/whitelist.txt
+++ b/domains/whitelist.txt
@@ -202,6 +202,7 @@ www.msftncsi.com
 www.no-ip.com
 www.plex.tv
 www.solaredge.com
+www.sony.co.uk
 www.synology.com
 www.twitter.com
 www.xboxlive.com


### PR DESCRIPTION
 Match found in https://adblock.mahakala.is:
   sony.co.uk
   www.sony.co.uk