### PR TITLE
Add amzn.to referral links

### DIFF
--- a/domains/referral-sites.txt
+++ b/domains/referral-sites.txt
@@ -1,6 +1,7 @@
 7eer.net
 ad.doubleclick.net
 affiliatefuture.com
+amzn.to
 anrdoezrs.net
 apmebf.com
 avantlink.com


### PR DESCRIPTION
The Amazon referral shortlink domain `amzn.to` is currently on [`hosts-file.net`'s phishing list](https://hosts-file.net/psh.txt), and I think it should be on this list (`referral-sites.txt`). Thank you for your consideration.