### PR TITLE
Added two URLs for Xbox achievement sync

### DIFF
--- a/domains/optional-list.txt
+++ b/domains/optional-list.txt
@@ -201,5 +201,9 @@ fpdownload.adobe.com
 entitlement.auth.adobe.com
 livepassdl.conviva.com
 
+# Xbox Achievements and game stats sync
+v10.events.data.microsoft.com
+v20.events.data.microsoft.com
+
 # streamelements.com (Blocked by Pi-hole regex)
 stats.streamelements.com


### PR DESCRIPTION
There are two domains missing that are used for Xbox achievement syncing on all Xbox One devices:

v10.events.data.microsoft.com
v20.events.data.microsoft.com

Both of these are in [Pi-Hole's commonly whitelisted domains](https://discourse.pi-hole.net/t/commonly-whitelisted-domains/212) and have been confirmed by Microsoft that these are used for achievements on Xbox.