### PR TITLE
(docker) - Add support for environment variable overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,13 @@ git clone https://github.com/anudeepND/whitelist.git
 cd whitelist/scripts
 ./whitelist.sh
 ```
-If you keep the `/etc/pihole` on a volume outside the container you need to change `PIHOLE_LOCATION`and `GRAVITY_UPDATE_COMMAND` variables based on your setup.
+If you keep the `/etc/pihole` on a volume outside the container you can set the `PIHOLE_LOCATION` and `GRAVITY_UPDATE_COMMAND` environment variables based on your setup which the scripts will honor. 
+
+For example, if your volume is at `/docker/pihole/etc/` and your container is named `mycontainer`:
+
+```
+PIHOLE_LOCATION=/docker/pihole/etc GRAVITY_UPDATE_COMMAND='docker exec -it mycontainer pihole -w -q' scripts/whitelist.sh 
+```
          
 ***For whitelist.txt***     
 ```

--- a/scripts/referral.sh
+++ b/scripts/referral.sh
@@ -5,8 +5,8 @@
 # Created by Anudeep
 #================================================================================
 TICK="[\e[32m ✔ \e[0m]"
-PIHOLE_LOCATION="/etc/pihole"
-GRAVITY_UPDATE_COMMAND="pihole -w -q"
+PIHOLE_LOCATION="${PIHOLE_LOCATION:-/etc/pihole}"
+GRAVITY_UPDATE_COMMAND="${GRAVITY_UPDATE_COMMAND:-pihole -w -q}"
 echo -e " \e[1m This file contains tracking and adserving domains. Run this script if you use specific service (like Slickdeals and Fatwallet etc.) that require certain adserving domains to be whitelisted. If you don't know what these services are, stay away from this list.  \e[0m"
 read -p "Do you want to continue (Y/N)? " -n 1 -r
 echo   
@@ -28,11 +28,11 @@ then
 	sleep 0.5
 	echo -e " ${TICK} \e[32m Removing duplicates... \e[0m"
 
-	mv "${PIHOLE_LOCATION}"/whitelist.txt /etc/pihole/whitelist.txt.old && cat "${PIHOLE_LOCATION}"/whitelist.txt.old | sort | uniq >> "${PIHOLE_LOCATION}"/whitelist.txt
+	mv "${PIHOLE_LOCATION}"/whitelist.txt ${PIHOLE_LOCATION}/whitelist.txt.old && cat "${PIHOLE_LOCATION}"/whitelist.txt.old | sort | uniq >> "${PIHOLE_LOCATION}"/whitelist.txt
 
 	wait
 	echo -e " [...] \e[32m Pi-hole gravity rebuilding lists. This may take a while \e[0m"
-	${GRAVITY_UPDATE_COMMAND} $(cat /etc/pihole/whitelist.txt | xargs) > /dev/null
+	${GRAVITY_UPDATE_COMMAND} $(cat ${PIHOLE_LOCATION}/whitelist.txt | xargs) > /dev/null
 	wait
 	echo -e " ${TICK} \e[32m Pi-hole's gravity updated \e[0m"
 	echo -e " ${TICK} \e[32m Done! \e[0m"

--- a/scripts/whitelist.sh
+++ b/scripts/whitelist.sh
@@ -5,8 +5,8 @@
 # Created by Anudeep (Slight change by cminion)
 #================================================================================
 TICK="[\e[32m ✔ \e[0m]"
-PIHOLE_LOCATION="/etc/pihole"
-GRAVITY_UPDATE_COMMAND="pihole -w -q"
+PIHOLE_LOCATION="${PIHOLE_LOCATION:-/etc/pihole}"
+GRAVITY_UPDATE_COMMAND="${GRAVITY_UPDATE_COMMAND:-pihole -w -q}"
 
 echo -e " \e[1m This script will download and add domains from the repo to whitelist.txt \e[0m"
 echo -e "\n"
@@ -26,7 +26,7 @@ echo -e " ${TICK} \e[32m Removing duplicates... \e[0m"
 mv "${PIHOLE_LOCATION}"/whitelist.txt "${PIHOLE_LOCATION}"/whitelist.txt.old && cat "${PIHOLE_LOCATION}"/whitelist.txt.old | sort | uniq >> "${PIHOLE_LOCATION}"/whitelist.txt
 
 echo -e " [...] \e[32m Pi-hole gravity rebuilding lists. This may take a while... \e[0m"
-${GRAVITY_UPDATE_COMMAND} $(cat /etc/pihole/whitelist.txt | xargs) > /dev/null
+${GRAVITY_UPDATE_COMMAND} $(cat ${PIHOLE_LOCATION}/whitelist.txt | xargs) > /dev/null
  
 echo -e " ${TICK} \e[32m Pi-hole's gravity updated \e[0m"
 echo -e " ${TICK} \e[32m Done! \e[0m"


### PR DESCRIPTION
Shouldnt need to edit files to make these changes, ideally. So adding
these as parameter expansions/default values lets users override them
in their shell (e.g. crontab or otherwise)

Added some words in the documentation to reflect this.