### PR TITLE
Support for Pi-hole running as Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ sudo python3 whitelist/scripts/whitelist.py
 
 ### How to determine an ad domain
 
-***Adam:ONE Assistant (Previously known as DNSthingy***
+***Adam:ONE Assistant (Previously known as DNSthingy)***
 
 [This browser extension](https://chrome.google.com/webstore/detail/adamone-assistant/fdmpekabnlekabjlimjkfmdjajnddgpc) will list all of the domains that are queried when a web page is loaded. You can often look at the list of domains and cherry pick the ones that appear to be ad-serving domains.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ git clone https://github.com/anudeepND/whitelist.git
 sudo python3 whitelist/scripts/whitelist.py --dir /home/docker/pihole/etc-pihole/ --docker
 ```
 
-
 **Note: You don't have to clone the repo every time you need to update whitelist file. Navigate to `whitelist/scripts` and run it again `sudo python3 whitelist.py`**
 * * *
 
@@ -137,7 +136,7 @@ sudo python3 whitelist/scripts/whitelist.py
 
 * * *
 
-### How do I determine an ad domain?
+### How to determine an ad domain
 
 ***Adam:ONE Assistant (Previously known as DNSthingy***
 

--- a/README.md
+++ b/README.md
@@ -1,91 +1,103 @@
 <p align="center">
-  <img width="550" src="https://raw.githubusercontent.com/anudeepND/whitelist/master/images/logo.png">
-</p>    
-      
+  <img width="550" alt="Whitelist logo" src="https://raw.githubusercontent.com/anudeepND/whitelist/master/images/logo.png">
+</p>
 <p align="center">  
   <a href="https://www.paypal.me/anudeepND"><img alt="Donate using Paypal" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"></a>
   &nbsp;&nbsp;
   <a href="https://liberapay.com/Anudeep/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg"></a>
 </p>
-         
-         
-# Commonly white listed domains for Pi-Hole (Compatible with Pi-Hole Docker Image).  
-          
+
+# Commonly white listed domains for Pi-Hole (Compatible with Pi-Hole Docker Image)
+
 A robust collection of commonly white listed websites borrowed from various sources including Pi-Hole subreddit, Pi-Hole forum, Pi-Hole GitHub repository and more!
 Add these domains to your Pi-Hole setup by running a script or manually and make your setup **trouble-free!**
-                
-Want to report a new domain? Want to report existing one? Feel free to file an <a href="https://github.com/anudeepND/whitelist/issues">issue</a>.
-         
-         
+
+Want to report a new domain? Want to report existing one? Feel free to file an [issue](https://github.com/anudeepND/whitelist/issues).
+
  <p align="center">
-  <img height="630" src="https://raw.githubusercontent.com/anudeepND/whitelist/master/images/whitelist.gif">
-</p> 
-         
+  <img height="630" alt="Whitelist install demo gif" src="https://raw.githubusercontent.com/anudeepND/whitelist/master/images/whitelist.gif">
+</p>
+
 * * *
-         
-## Main features:
-       
+
+## Main features
+
 - The entire repo is curated.
 - New domains are added frequently.
 - Supports Pi-Hole Docker installation.
 - Comes with a simple install/uninstall scripts i.e you can add all domains with comments automatically at an instant.
 - Domains are categorized and are included in 3 different files.
 - All the domains will have comments to let you know about the domain.
-- If you are a beginner to Pi-Hole, adding these sites will solve issues with host files that block legit websites. 
-       
-***
-     
+- If you are a beginner to Pi-Hole, adding these sites will solve issues with host files that block legit websites.
+
+* * *
+
 ## Description
-          
+
 |      File Name     | Domain Count |                                                                                                                                                                Description                                                                                                                                                                | Update Frequency |                                             Raw Link                                            |
 |:------------------:|:------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:----------------:|:-----------------------------------------------------------------------------------------------:|
 | whitelist.txt      | 188          | This file contain domains that are **safe** to whitelist i.e it does not contain any tracking or advertising sites. Adding this file fixes many problems like YouTube watch history, videos on news sites and so on. If you want to report additional domain feel free to file an [issue](https://github.com/anudeepND/whitelist/issues). | Occasionally     | [link](https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt)      |
 | referral-sites.txt | 72           | People who use services like Slickdeals and Fatwallet needs a few sites (most of  them are either trackers or ads) to be whitelisted to work properly. This file contains some analytics and ad serving sites like **doubleclick.net** and others. **If you don't know what these services are, stay away from this list.**               | Occasionally     | [link](https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/referral-sites.txt) |
-| optional-list.txt  | --           | This file contain domains that are needed to be whitelisted depending on the service you use. It may contain some tracking site but sometimes it's necessary to add bad domains to make a few services to work. Currently there is no script for this list, you have to add domains manually to your Pi-Hole.                             | Occasionally     | [link](https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/optional-list.txt)  |    
-             
-***
-           
+| optional-list.txt  | --           | This file contain domains that are needed to be whitelisted depending on the service you use. It may contain some tracking site but sometimes it's necessary to add bad domains to make a few services to work. Currently there is no script for this list, you have to add domains manually to your Pi-Hole.                             | Occasionally     | [link](https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/optional-list.txt)  |
+
+* * *
+
 ## Installation
- 
+
  Make sure you have **python3** installed on your machine. You can simply install it by using `sudo apt install python3`
-      
-***For whitelist.txt***     
-```
+
+***For whitelist.txt***
+
+```shell
 git clone https://github.com/anudeepND/whitelist.git
 sudo python3 whitelist/scripts/whitelist.py
 ```
-             
-***For referral-sites.txt***          
-```
+
+***For referral-sites.txt***
+
+```shell
 git clone https://github.com/anudeepND/whitelist.git
 cd whitelist/scripts
 sudo ./referral.sh
 ```
 
-If you are using Pi-hole 5.0 or later, the comment field has a unique string - `qjz9zk` to uniquely identify the domains added by this script so the user can remove the domains without affecting other whitelisted sites. 
+If you are using Pi-hole 5.0 or later, the comment field has a unique string - `qjz9zk` to uniquely identify the domains added by this script so the user can remove the domains without affecting other whitelisted sites.
 
-        
-***For optional-list.txt***     
-You can add it manually depending upon the service you use. 
-           
- ***For Docker installation***           
+***For optional-list.txt***
+You can add it manually depending upon the service you use.
+
+ ***For Docker installation (with Python3 support)***
+
  Access you running Pi-Hole container by `docker exec -it <container-ID> bash` and proceed with the steps given below:
-```
+
+```shell
 git clone https://github.com/anudeepND/whitelist.git
 sudo python3 whitelist/scripts/whitelist.py
 ```
-If you keep the `/etc/pihole` on a volume outside the container you need to change pass the appropriate values to the variables based on your setup.
-                   
-**Note: You don't have to clone the repo every time you need to update whitelist file. Navigate to `whitelist/scripts` and run it again `sudo python3 whitelist.py`**         
-***
-   
-## Uninstall
-         
-         
- <p align="center">
-  <img height="630" src="https://raw.githubusercontent.com/anudeepND/whitelist/master/images/uninstall.gif">
-</p> 
 
+ ***For Docker installation (without Python3 support) or /etc/pihole on different directory***
+
+ You can pass two optional arguments to whitelist.py and uninstall.py:
+
+```Text
+ -d or --dir to specify the Pi-hole etc directory (in normal install should be /etc/pihole)
+ -D or --docker to specify if Pi-hole is running as Docker container
+ ```
+
+```shell
+git clone https://github.com/anudeepND/whitelist.git
+sudo python3 whitelist/scripts/whitelist.py --dir /home/docker/pihole/etc-pihole/ --docker
+```
+
+
+**Note: You don't have to clone the repo every time you need to update whitelist file. Navigate to `whitelist/scripts` and run it again `sudo python3 whitelist.py`**
+* * *
+
+## Uninstall
+
+ <p align="center">
+  <img height="630" alt="Whitelist uninstall demo gif"src="https://raw.githubusercontent.com/anudeepND/whitelist/master/images/uninstall.gif">
+</p>
 
 As mentioned earlier, the unique string (`qjz9zk`) will come in handy while removing the domains from the database. It uses LIKE operator of the SQLite to match the wildcard string present in the comment section.
 
@@ -93,51 +105,55 @@ As mentioned earlier, the unique string (`qjz9zk`) will come in handy while remo
 This statement will remove the domain only if it is present in the exact whitelist section and having the string `qjz9zk`. Domains in the regex list will not be removed by this script.
 
 The older version of the Pi-hole uses a simple text file to store the entries. In this case the script will match the domains present in your Pi-hole to the domains present in the GitHub repo and removes them accordingly.
-           
-**To remove the domains:**    
+
+**To remove the domains:**
 `sudo python3 uninstall.py`
-        
-***
-     
+
+* * *
+
 ## For Automated Update
-```
+
+```shell
 cd /opt/
 sudo git clone https://github.com/anudeepND/whitelist.git
 ```
+
 Make the script to run the script at 1AM on the last day of the week
 
-`sudo nano /etc/crontab`
+```shell
+sudo nano /etc/crontab
+```
 
-Add this line at the end of the file:       
-`0 1 * * */7     root    /opt/whitelist/scripts/whitelist.py`
+Add this line at the end of the file:
+
+```Text
+0 1 * * */7     root    /opt/whitelist/scripts/whitelist.py
+```
 
 CTRL + X then Y and Enter
 
-```
+```shell
 sudo python3 whitelist/scripts/whitelist.py
 ```
-   
-***     
-      
+
+* * *
+
 ### How do I determine an ad domain?
-         
+
 ***Adam:ONE Assistant (Previously known as DNSthingy***
-         
-<a href="https://chrome.google.com/webstore/detail/adamone-assistant/fdmpekabnlekabjlimjkfmdjajnddgpc">This browser extension</a> will list all of the domains that are queried when a web page is loaded. You can often look at the list of domains and cherry pick the ones that appear to be ad-serving domains.     
-        
-      
-***Using inbuilt Developer tool***     
-          
+
+[This browser extension](https://chrome.google.com/webstore/detail/adamone-assistant/fdmpekabnlekabjlimjkfmdjajnddgpc) will list all of the domains that are queried when a web page is loaded. You can often look at the list of domains and cherry pick the ones that appear to be ad-serving domains.
+
+***Using inbuilt Developer tool***
+
 For Chrome ctrl+shift+I will land you in Developer tools menu.
-           
-          
-***Using an Android app*** 
-     
-[Net Guard](https://play.google.com/store/apps/details?id=eu.faircode.netguard) is an Android app that can be used to monitor any specific apps, works on unrooted devices too.   
-        
-             
-***
-   
+
+***Using an Android app***
+
+[Net Guard](https://play.google.com/store/apps/details?id=eu.faircode.netguard) is an Android app that can be used to monitor any specific apps, works on unrooted devices too.
+
+* * *
+
 ### Donation
 
 All donations are welcome and any amount of money will help me to maintain this project :)
@@ -146,9 +162,10 @@ All donations are welcome and any amount of money will help me to maintain this 
   &nbsp;&nbsp;
   <a href="https://liberapay.com/Anudeep/donate"><img alt="Donate using Liberapay" src="https://liberapay.com/assets/widgets/donate.svg"></a>
 </p>
-   
+
 ### Licence
-```
+
+```Text
 MIT License
 
 Copyright (c) 2019 Anudeep ND <anudeep@protonmail.com>

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ Add these domains to your Pi-Hole setup by running a script or manually and make
 
 Want to report a new domain? Want to report existing one? Feel free to file an [issue](https://github.com/anudeepND/whitelist/issues).
 
- <p align="center">
-  <img height="630" alt="Whitelist install demo gif" src="https://raw.githubusercontent.com/anudeepND/whitelist/master/images/whitelist.gif">
-</p>
+![Whitelist install demo gif](https://raw.githubusercontent.com/anudeepND/whitelist/master/images/whitelist.gif)
 
 * * *
 
@@ -48,14 +46,14 @@ Want to report a new domain? Want to report existing one? Feel free to file an [
 
 ***For whitelist.txt***
 
-```shell
+```Shell
 git clone https://github.com/anudeepND/whitelist.git
 sudo python3 whitelist/scripts/whitelist.py
 ```
 
 ***For referral-sites.txt***
 
-```shell
+```Shell
 git clone https://github.com/anudeepND/whitelist.git
 cd whitelist/scripts
 sudo ./referral.sh
@@ -70,7 +68,7 @@ You can add it manually depending upon the service you use.
 
  Access you running Pi-Hole container by `docker exec -it <container-ID> bash` and proceed with the steps given below:
 
-```shell
+```Shell
 git clone https://github.com/anudeepND/whitelist.git
 sudo python3 whitelist/scripts/whitelist.py
 ```
@@ -84,7 +82,7 @@ sudo python3 whitelist/scripts/whitelist.py
  -D or --docker to specify if Pi-hole is running as Docker container
  ```
 
-```shell
+```Shell
 git clone https://github.com/anudeepND/whitelist.git
 sudo python3 whitelist/scripts/whitelist.py --dir /home/docker/pihole/etc-pihole/ --docker
 ```
@@ -95,13 +93,14 @@ sudo python3 whitelist/scripts/whitelist.py --dir /home/docker/pihole/etc-pihole
 
 ## Uninstall
 
- <p align="center">
-  <img height="630" alt="Whitelist uninstall demo gif"src="https://raw.githubusercontent.com/anudeepND/whitelist/master/images/uninstall.gif">
-</p>
+![Whitelist uninstall demo gif](https://raw.githubusercontent.com/anudeepND/whitelist/master/images/uninstall.gif)
 
 As mentioned earlier, the unique string (`qjz9zk`) will come in handy while removing the domains from the database. It uses LIKE operator of the SQLite to match the wildcard string present in the comment section.
 
-`SELECT * FROM domainlist WHERE type = 0 AND comment LIKE '%qjz9zk%'`
+```SQL
+SELECT * FROM domainlist WHERE type = 0 AND comment LIKE '%qjz9zk%'
+```
+
 This statement will remove the domain only if it is present in the exact whitelist section and having the string `qjz9zk`. Domains in the regex list will not be removed by this script.
 
 The older version of the Pi-hole uses a simple text file to store the entries. In this case the script will match the domains present in your Pi-hole to the domains present in the GitHub repo and removes them accordingly.
@@ -113,14 +112,14 @@ The older version of the Pi-hole uses a simple text file to store the entries. I
 
 ## For Automated Update
 
-```shell
+```Shell
 cd /opt/
 sudo git clone https://github.com/anudeepND/whitelist.git
 ```
 
 Make the script to run the script at 1AM on the last day of the week
 
-```shell
+```Shell
 sudo nano /etc/crontab
 ```
 
@@ -132,7 +131,7 @@ Add this line at the end of the file:
 
 CTRL + X then Y and Enter
 
-```shell
+```Shell
 sudo python3 whitelist/scripts/whitelist.py
 ```
 

--- a/scripts/uninstall.py
+++ b/scripts/uninstall.py
@@ -50,6 +50,15 @@ def dir_path(string):
         raise NotADirectoryError(string)
 
 
+def restart_pihole(docker):
+    if docker is True:
+        subprocess.call("docker exec -it pihole pihole restartdns reload",
+                        shell=True, stdout=subprocess.DEVNULL)
+    else:
+        subprocess.call(['pihole', 'restartdns', 'reload'],
+                        stdout=subprocess.DEVNULL)
+
+
 parser = argparse.ArgumentParser()
 parser.add_argument("-d", "--dir", type=dir_path,
                     help="optional: Pi-hole etc directory")
@@ -181,12 +190,7 @@ if db_exists:
             print('[i] The database connection is closed')
 
             print('[i] Restarting Pi-hole. This could take a few seconds')
-            if args.docker is True:
-                subprocess.call("docker exec -it pihole pihole restartdns reload",
-                                shell=True, stdout=subprocess.DEVNULL)
-            else:
-                subprocess.call(['pihole', 'restartdns', 'reload'],
-                                stdout=subprocess.DEVNULL)
+            restart_pihole(args.docker)
             print('\n')
             print('Done. Happy ad-blocking :)')
             print('\n')
@@ -226,12 +230,8 @@ else:
             fWrite.write("{}\n".format(line))
 
     print('[i] Restarting Pi-hole. This could take a few seconds')
-    subprocess.call(['pihole', 'restartdns', 'reload'],
-                    stdout=subprocess.DEVNULL)
-
+    restart_pihole(args.docker)
     print('[i] Done - Domains are now removed your Pi-Hole whitelist')
-    subprocess.call(['pihole', 'restartdns', 'reload'],
-                    stdout=subprocess.DEVNULL)
     print('\n')
     print('Happy ad-blocking :)')
     print('\n')

--- a/scripts/uninstall.py
+++ b/scripts/uninstall.py
@@ -3,6 +3,7 @@
 # Created by Anudeep
 # ================================================================================
 import os
+import argparse
 import sqlite3
 import subprocess
 from urllib.request import Request, urlopen
@@ -42,9 +43,28 @@ def fetch_whitelist_url(url):
     return response
 
 
+def dir_path(string):
+    if os.path.isdir(string):
+        return string
+    else:
+        raise NotADirectoryError(string)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-d", "--dir", type=dir_path,
+                    help="optional: Pi-hole etc directory")
+parser.add_argument(
+    "-D", "--docker",  action='store_true', help="optional: set if you're using Pi-hole in Docker environment")
+args = parser.parse_args()
+
+if args.dir:
+    pihole_location = args.dir
+else:
+    pihole_location = r'/etc/pihole'
+
+
 whitelist_remote_url = 'https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt'
 remote_sql_url = 'https://raw.githubusercontent.com/anudeepND/whitelist/master/scripts/domains.sql'
-pihole_location = r'/etc/pihole'
 gravity_whitelist_location = os.path.join(pihole_location, 'whitelist.txt')
 gravity_db_location = os.path.join(pihole_location, 'gravity.db')
 anudeep_whitelist_location = os.path.join(
@@ -161,9 +181,12 @@ if db_exists:
             print('[i] The database connection is closed')
 
             print('[i] Restarting Pi-hole. This could take a few seconds')
-            subprocess.call(['pihole', 'restartdns', 'reload'],
-                            stdout=subprocess.DEVNULL)
-
+            if args.docker is True:
+                subprocess.call("docker exec -it pihole pihole restartdns reload",
+                                shell=True, stdout=subprocess.DEVNULL)
+            else:
+                subprocess.call(['pihole', 'restartdns', 'reload'],
+                                stdout=subprocess.DEVNULL)
             print('\n')
             print('Done. Happy ad-blocking :)')
             print('\n')

--- a/scripts/uninstall.py
+++ b/scripts/uninstall.py
@@ -1,31 +1,33 @@
 # Project homepage: https://github.com/anudeepND/whitelist
 # Licence: https://github.com/anudeepND/whitelist/blob/master/LICENSE
 # Created by Anudeep
-#================================================================================
+# ================================================================================
 import os
 import sqlite3
 import subprocess
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError, URLError
 
+
 def fetch_whitelist_url(url):
 
     if not url:
         return
 
-    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:71.0) Gecko/20100101 Firefox/71.0'}
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:71.0) Gecko/20100101 Firefox/71.0'}
 
     try:
         response = urlopen(Request(url, headers=headers))
     except HTTPError as e:
         print('[X] HTTP Error:', e.code, 'whilst fetching', url)
-        print ('\n')
-        print ('\n')
+        print('\n')
+        print('\n')
         exit(1)
     except URLError as e:
         print('[X] URL Error:', e.reason, 'whilst fetching', url)
-        print ('\n')
-        print ('\n')
+        print('\n')
+        print('\n')
         exit(1)
 
     # Read and decode
@@ -39,12 +41,14 @@ def fetch_whitelist_url(url):
     # Return the hosts
     return response
 
+
 whitelist_remote_url = 'https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt'
 remote_sql_url = 'https://raw.githubusercontent.com/anudeepND/whitelist/master/scripts/domains.sql'
 pihole_location = r'/etc/pihole'
 gravity_whitelist_location = os.path.join(pihole_location, 'whitelist.txt')
 gravity_db_location = os.path.join(pihole_location, 'gravity.db')
-anudeep_whitelist_location = os.path.join(pihole_location, 'anudeep-whitelist.txt')
+anudeep_whitelist_location = os.path.join(
+    pihole_location, 'anudeep-whitelist.txt')
 
 db_exists = False
 sqliteConnection = None
@@ -56,20 +60,20 @@ whitelist_anudeep_local = set()
 whitelist_old_anudeep = set()
 
 os.system('clear')
-print ('\n')
-print ('''
+print('\n')
+print('''
 If you are using Pi-hole 5.0 or later, then this script will remove the domains which are only added by my script. 
 Any other domains added by you will stay as it is. 
 ''')
-print ('\n')
+print('\n')
 
 # Check for pihole path exsists
 if os.path.exists(pihole_location):
     print('[i] Pi-hole path exists')
 else:
     print("[X] {} was not found".format(pihole_location))
-    print ('\n')
-    print ('\n')
+    print('\n')
+    print('\n')
     exit(1)
 
 # Check for write access to /etc/pihole
@@ -79,9 +83,10 @@ if os.access(pihole_location, os.X_OK | os.W_OK):
     remote_whitelist_lines = whitelist_str.count('\n')
     remote_whitelist_lines += 1
 else:
-    print("[X] Write access is not available for {}. Please run as root or other privileged user" .format(pihole_location))
-    print ('\n')
-    print ('\n')
+    print("[X] Write access is not available for {}. Please run as root or other privileged user" .format(
+        pihole_location))
+    print('\n')
+    print('\n')
     exit(1)
 
 # Determine whether we are using DB or not
@@ -104,11 +109,12 @@ else:
     print('[i] Legacy Pi-hole detected (Version older than 5.0)')
 
 if whitelist_str:
-    whitelist_remote.update(x for x in map(str.strip, whitelist_str.splitlines()) if x and x[:1] != '#')
+    whitelist_remote.update(x for x in map(
+        str.strip, whitelist_str.splitlines()) if x and x[:1] != '#')
 else:
     print('[X] No remote domains were found.')
-    print ('\n')
-    print ('\n')
+    print('\n')
+    print('\n')
     exit(1)
 
 if db_exists:
@@ -119,10 +125,13 @@ if db_exists:
         sqliteConnection = sqlite3.connect(gravity_db_location)
         cursor = sqliteConnection.cursor()
         print('[i] Successfully Connected to Gravity database')
-        total_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 AND comment LIKE '%qjz9zk%' ")
-        print("[i] There are a total of {} domains in your whitelist which are added by my script" .format(len(total_domains.fetchall())))
+        total_domains = cursor.execute(
+            " SELECT * FROM domainlist WHERE type = 0 AND comment LIKE '%qjz9zk%' ")
+        print("[i] There are a total of {} domains in your whitelist which are added by my script" .format(
+            len(total_domains.fetchall())))
         print('[i] Removing domains in the Gravity database')
-        cursor.execute (" DELETE FROM domainlist WHERE type = 0 AND comment LIKE '%qjz9zk%' ")
+        cursor.execute(
+            " DELETE FROM domainlist WHERE type = 0 AND comment LIKE '%qjz9zk%' ")
 
         sqliteConnection.commit()
 
@@ -132,15 +141,17 @@ if db_exists:
         if numberOfDomains > 1:
             numberOfDomains = numberOfDomains // 2
         print("[i] {} domains are removed" .format(numberOfDomains))
-        remaining_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 OR type = 2 ")
-        print("[i] There are a total of {} domains remaining in your whitelist" .format(len(remaining_domains.fetchall())))
+        remaining_domains = cursor.execute(
+            " SELECT * FROM domainlist WHERE type = 0 OR type = 2 ")
+        print("[i] There are a total of {} domains remaining in your whitelist" .format(
+            len(remaining_domains.fetchall())))
 
         cursor.close()
 
     except sqlite3.Error as error:
         print('[X] Failed to remove domains from Gravity database', error)
-        print ('\n')
-        print ('\n')
+        print('\n')
+        print('\n')
         exit(1)
 
     finally:
@@ -150,27 +161,31 @@ if db_exists:
             print('[i] The database connection is closed')
 
             print('[i] Restarting Pi-hole. This could take a few seconds')
-            subprocess.call(['pihole', 'restartdns', 'reload'], stdout=subprocess.DEVNULL)
+            subprocess.call(['pihole', 'restartdns', 'reload'],
+                            stdout=subprocess.DEVNULL)
 
-            print ('\n')
+            print('\n')
             print('Done. Happy ad-blocking :)')
-            print ('\n')
+            print('\n')
             print('Star me on GitHub: https://github.com/anudeepND/whitelist')
             print('Buy me a coffee: https://paypal.me/anudeepND')
-            print ('\n')
+            print('\n')
 
 else:
     if os.path.isfile(gravity_whitelist_location) and os.path.getsize(gravity_whitelist_location) > 0:
         with open(gravity_whitelist_location, 'r') as fRead:
-            whitelist_local.update(x for x in map(str.strip, fRead) if x and x[:1] != '#')
+            whitelist_local.update(x for x in map(
+                str.strip, fRead) if x and x[:1] != '#')
 
     if whitelist_local:
-        print("[i] {} existing whitelisted domains identified" .format(len(whitelist_local)))
-        
+        print("[i] {} existing whitelisted domains identified" .format(
+            len(whitelist_local)))
+
         if os.path.isfile(anudeep_whitelist_location) and os.path.getsize(anudeep_whitelist_location) > 0:
             print('[i] Existing anudeep-whitelist install identified')
             with open(anudeep_whitelist_location, 'r') as fOpen:
-                whitelist_old_anudeep.update(x for x in map(str.strip, fOpen) if x and x[:1] != '#')
+                whitelist_old_anudeep.update(x for x in map(
+                    str.strip, fOpen) if x and x[:1] != '#')
 
                 if whitelist_old_anudeep:
                     whitelist_local.difference_update(whitelist_old_anudeep)
@@ -181,19 +196,22 @@ else:
             print('[i] Removing domains that match the remote repo')
             whitelist_local.difference_update(whitelist_remote)
 
-    print("[i] Adding exsisting {} domains to {}" .format(len(whitelist_local), gravity_whitelist_location))
+    print("[i] Adding exsisting {} domains to {}" .format(
+        len(whitelist_local), gravity_whitelist_location))
     with open(gravity_whitelist_location, 'w') as fWrite:
         for line in sorted(whitelist_local):
             fWrite.write("{}\n".format(line))
 
     print('[i] Restarting Pi-hole. This could take a few seconds')
-    subprocess.call(['pihole', 'restartdns', 'reload'], stdout=subprocess.DEVNULL)
+    subprocess.call(['pihole', 'restartdns', 'reload'],
+                    stdout=subprocess.DEVNULL)
 
     print('[i] Done - Domains are now removed your Pi-Hole whitelist')
-    subprocess.call(['pihole', 'restartdns', 'reload'], stdout=subprocess.DEVNULL)
-    print ('\n')
+    subprocess.call(['pihole', 'restartdns', 'reload'],
+                    stdout=subprocess.DEVNULL)
+    print('\n')
     print('Happy ad-blocking :)')
-    print ('\n')
+    print('\n')
     print('Star me on GitHub: https://github.com/anudeepND/whitelist')
     print('Buy me a coffee: https://paypal.me/anudeepND')
-    print ('\n')
+    print('\n')

--- a/scripts/whitelist.py
+++ b/scripts/whitelist.py
@@ -1,31 +1,33 @@
 # Project homepage: https://github.com/anudeepND/whitelist
 # Licence: https://github.com/anudeepND/whitelist/blob/master/LICENSE
 # Created by Anudeep
-#================================================================================
+# ================================================================================
 import os
 import sqlite3
 import subprocess
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError, URLError
 
+
 def fetch_whitelist_url(url):
 
     if not url:
         return
 
-    headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:71.0) Gecko/20100101 Firefox/71.0'}
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:71.0) Gecko/20100101 Firefox/71.0'}
 
     try:
         response = urlopen(Request(url, headers=headers))
     except HTTPError as e:
         print('[X] HTTP Error:', e.code, 'whilst fetching', url)
-        print ('\n')
-        print ('\n')
+        print('\n')
+        print('\n')
         exit(1)
     except URLError as e:
         print('[X] URL Error:', e.reason, 'whilst fetching', url)
-        print ('\n')
-        print ('\n')
+        print('\n')
+        print('\n')
         exit(1)
 
     # Read and decode
@@ -39,12 +41,14 @@ def fetch_whitelist_url(url):
     # Return the hosts
     return response
 
+
 whitelist_remote_url = 'https://raw.githubusercontent.com/anudeepND/whitelist/master/domains/whitelist.txt'
 remote_sql_url = 'https://raw.githubusercontent.com/anudeepND/whitelist/master/scripts/domains.sql'
 pihole_location = r'/etc/pihole'
 gravity_whitelist_location = os.path.join(pihole_location, 'whitelist.txt')
 gravity_db_location = os.path.join(pihole_location, 'gravity.db')
-anudeep_whitelist_location = os.path.join(pihole_location, 'anudeep-whitelist.txt')
+anudeep_whitelist_location = os.path.join(
+    pihole_location, 'anudeep-whitelist.txt')
 
 db_exists = False
 sqliteConnection = None
@@ -56,12 +60,12 @@ whitelist_anudeep_local = set()
 whitelist_old_anudeep = set()
 
 os.system('clear')
-print ('\n')
-print ('''
+print('\n')
+print('''
 This script will download and add domains from the repo to whitelist. 
 All the domains in this list are safe to add and does not contain any tracking or adserving domains.
 ''')
-print ('\n')
+print('\n')
 
 # Check for pihole path exsists
 if os.path.exists(pihole_location):
@@ -71,8 +75,8 @@ else:
 
     print("[X] {} was not found".format(pihole_location))
 
-    print ('\n')
-    print ('\n')
+    print('\n')
+    print('\n')
     exit(1)
 
 
@@ -84,9 +88,10 @@ if os.access(pihole_location, os.X_OK | os.W_OK):
     remote_whitelist_lines += 1
 
 else:
-    print("[X] Write access is not available for {}. Please run as root or other privileged user" .format(pihole_location))
-    print ('\n')
-    print ('\n')
+    print("[X] Write access is not available for {}. Please run as root or other privileged user" .format(
+        pihole_location))
+    print('\n')
+    print('\n')
     exit(1)
 
 # Determine whether we are using DB or not
@@ -99,7 +104,8 @@ if os.path.isfile(gravity_db_location) and os.path.getsize(gravity_db_location) 
     remote_sql_lines += 1
 
     if len(remote_sql_str) > 0:
-        print("[i] {} domains and {} SQL queries discovered" .format(remote_whitelist_lines, remote_sql_lines))
+        print("[i] {} domains and {} SQL queries discovered" .format(
+            remote_whitelist_lines, remote_sql_lines))
     else:
         print('[X] No remote SQL queries found')
         print('\n')
@@ -110,11 +116,12 @@ else:
 
 # If domains were fetched, remove any comments and add to set
 if whitelist_str:
-    whitelist_remote.update(x for x in map(str.strip, whitelist_str.splitlines()) if x and x[:1] != '#')
+    whitelist_remote.update(x for x in map(
+        str.strip, whitelist_str.splitlines()) if x and x[:1] != '#')
 else:
     print('[X] No remote domains were found.')
-    print ('\n')
-    print ('\n')
+    print('\n')
+    print('\n')
     exit(1)
 
 if db_exists:
@@ -136,16 +143,19 @@ if db_exists:
         if numberOfDomains > 1:
             numberOfDomains = numberOfDomains // 2
         #print(f'[i] {numberOfDomains} domains are added to whitelist out of {len(whitelist_remote)}')
-        print("[i] {} domains are added to whitelist out of {}" .format(numberOfDomains, len(whitelist_remote)))
-        total_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 OR type = 2 ")
+        print("[i] {} domains are added to whitelist out of {}" .format(
+            numberOfDomains, len(whitelist_remote)))
+        total_domains = cursor.execute(
+            " SELECT * FROM domainlist WHERE type = 0 OR type = 2 ")
         #print(f'[i] There are a total of {len(total_domains.fetchall())} domains in your whitelist')
-        print("[i] There are a total of {} domains in your whitelist" .format(len(total_domains.fetchall())))
+        print("[i] There are a total of {} domains in your whitelist" .format(
+            len(total_domains.fetchall())))
         cursor.close()
 
     except sqlite3.Error as error:
         print('[X] Failed to insert domains into Gravity database', error)
-        print ('\n')
-        print ('\n')
+        print('\n')
+        print('\n')
         exit(1)
 
     finally:
@@ -153,27 +163,31 @@ if db_exists:
             sqliteConnection.close()
             print('[i] The database connection is closed')
             print('[i] Restarting Pi-hole. This could take a few seconds')
-            subprocess.call(['pihole', 'restartdns', 'reload'], stdout=subprocess.DEVNULL)
-            print ('\n')
+            subprocess.call(['pihole', 'restartdns', 'reload'],
+                            stdout=subprocess.DEVNULL)
+            print('\n')
             print('Done. Happy ad-blocking :)')
-            print ('\n')
+            print('\n')
             print('Star me on GitHub: https://github.com/anudeepND/whitelist')
             print('Buy me a coffee: https://paypal.me/anudeepND')
-            print ('\n')
+            print('\n')
 
 else:
 
     if os.path.isfile(gravity_whitelist_location) and os.path.getsize(gravity_whitelist_location) > 0:
         print('[i] Collecting existing entries from whitelist.txt')
         with open(gravity_whitelist_location, 'r') as fRead:
-            whitelist_local.update(x for x in map(str.strip, fRead) if x and x[:1] != '#')
+            whitelist_local.update(x for x in map(
+                str.strip, fRead) if x and x[:1] != '#')
 
     if whitelist_local:
-        print("[i] {} existing whitelists identified".format(len(whitelist_local)))
+        print("[i] {} existing whitelists identified".format(
+            len(whitelist_local)))
         if os.path.isfile(anudeep_whitelist_location) and os.path.getsize(anudeep_whitelist_location) > 0:
             print('[i] Existing anudeep-whitelist install identified')
             with open(anudeep_whitelist_location, 'r') as fOpen:
-                whitelist_old_anudeep.update(x for x in map(str.strip, fOpen) if x and x[:1] != '#')
+                whitelist_old_anudeep.update(x for x in map(
+                    str.strip, fOpen) if x and x[:1] != '#')
 
                 if whitelist_old_anudeep:
                     print('[i] Removing previously installed whitelist')
@@ -182,7 +196,8 @@ else:
     print("[i] Syncing with {}" .format(whitelist_remote_url))
     whitelist_local.update(whitelist_remote)
 
-    print("[i] Outputting {} domains to {}" .format(len(whitelist_local), gravity_whitelist_location))
+    print("[i] Outputting {} domains to {}" .format(
+        len(whitelist_local), gravity_whitelist_location))
     with open(gravity_whitelist_location, 'w') as fWrite:
         for line in sorted(whitelist_local):
             fWrite.write("{}\n".format(line))
@@ -193,9 +208,10 @@ else:
 
     print('[i] Done - Domains are now added to your Pi-Hole whitelist\n')
     print('[i] Restarting Pi-hole. This could take a few seconds')
-    subprocess.call(['pihole', 'restartdns', 'reload'], stdout=subprocess.DEVNULL)
+    subprocess.call(['pihole', 'restartdns', 'reload'],
+                    stdout=subprocess.DEVNULL)
     print('[i] Done. Happy ad-blocking :)')
-    print ('\n')
+    print('\n')
     print('Star me on GitHub: https://github.com/anudeepND/whitelist')
     print('Buy me a coffee: https://paypal.me/anudeepND')
-    print ('\n')
+    print('\n')

--- a/scripts/whitelist.py
+++ b/scripts/whitelist.py
@@ -50,6 +50,15 @@ def dir_path(string):
         raise NotADirectoryError(string)
 
 
+def restart_pihole(docker):
+    if docker is True:
+        subprocess.call("docker exec -it pihole pihole restartdns reload",
+                        shell=True, stdout=subprocess.DEVNULL)
+    else:
+        subprocess.call(['pihole', 'restartdns', 'reload'],
+                        stdout=subprocess.DEVNULL)
+
+
 parser = argparse.ArgumentParser()
 parser.add_argument("-d", "--dir", type=dir_path,
                     help="optional: Pi-hole etc directory")
@@ -91,7 +100,7 @@ print('\n')
 if os.path.exists(pihole_location):
     print('[i] Pi-hole path exists')
 else:
-   # print(f'[X] {pihole_location} was not found')
+    # print(f'[X] {pihole_location} was not found')
 
     print("[X] {} was not found".format(pihole_location))
 
@@ -162,12 +171,12 @@ if db_exists:
         numberOfDomains = sqliteConnection.total_changes
         if numberOfDomains > 1:
             numberOfDomains = numberOfDomains // 2
-        #print(f'[i] {numberOfDomains} domains are added to whitelist out of {len(whitelist_remote)}')
+        # print(f'[i] {numberOfDomains} domains are added to whitelist out of {len(whitelist_remote)}')
         print("[i] {} domains are added to whitelist out of {}" .format(
             numberOfDomains, len(whitelist_remote)))
         total_domains = cursor.execute(
             " SELECT * FROM domainlist WHERE type = 0 OR type = 2 ")
-        #print(f'[i] There are a total of {len(total_domains.fetchall())} domains in your whitelist')
+        # print(f'[i] There are a total of {len(total_domains.fetchall())} domains in your whitelist')
         print("[i] There are a total of {} domains in your whitelist" .format(
             len(total_domains.fetchall())))
         cursor.close()
@@ -183,12 +192,7 @@ if db_exists:
             sqliteConnection.close()
             print('[i] The database connection is closed')
             print('[i] Restarting Pi-hole. This could take a few seconds')
-            if args.docker is True:
-                subprocess.call("docker exec -it pihole pihole restartdns reload",
-                                shell=True, stdout=subprocess.DEVNULL)
-            else:
-                subprocess.call(['pihole', 'restartdns', 'reload'],
-                                stdout=subprocess.DEVNULL)
+            restart_pihole(args.docker)
             print('\n')
             print('Done. Happy ad-blocking :)')
             print('\n')
@@ -232,8 +236,7 @@ else:
 
     print('[i] Done - Domains are now added to your Pi-Hole whitelist\n')
     print('[i] Restarting Pi-hole. This could take a few seconds')
-    subprocess.call(['pihole', 'restartdns', 'reload'],
-                    stdout=subprocess.DEVNULL)
+    restart_pihole(args.docker)
     print('[i] Done. Happy ad-blocking :)')
     print('\n')
     print('Star me on GitHub: https://github.com/anudeepND/whitelist')


### PR DESCRIPTION
- Added -d --dir & -D --docker optional arguments.

> With -d or --dir you can specify the actual /etc/pihole directory, useful if Pi-hole is running under as Docker container.
> With` -D or --docker you can specify if Pi-hole is running as Docker container.

- Add information about optional arguments in the readme
- Fixes for out of specs readme MD where possible
- Fix a double reboot in uninstall script

I'm a C++ programmer, never coded in Python, I've tested my code in Linux environment with Python 3.7.3 and it's working fine.
Linted with VSCode 1.48.2 with Python extension v2020.8.105369