### PR TITLE
remove error prone total_changes function introduced in #158

### DIFF
--- a/scripts/uninstall.py
+++ b/scripts/uninstall.py
@@ -120,20 +120,18 @@ if db_exists:
         cursor = sqliteConnection.cursor()
         print('[i] Successfully Connected to Gravity database')
         total_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 AND comment LIKE '%qjz9zk%' ")
-        print("[i] There are a total of {} domains in your whitelist which are added by my script" .format(len(total_domains.fetchall())))
+        
+        totalDomains = len(total_domains.fetchall())
+        print("[i] There are a total of {} domains in your whitelist which are added by my script" .format(total_domains))
         print('[i] Removing domains in the Gravity database')
         cursor.execute (" DELETE FROM domainlist WHERE type = 0 AND comment LIKE '%qjz9zk%' ")
 
         sqliteConnection.commit()
 
-        # total_changes is returning 2x the actual value. ¯\_(ツ)_/¯
-        # if I made a mistake, please create a PR
-        numberOfDomains = sqliteConnection.total_changes
-        if numberOfDomains > 1:
-            numberOfDomains = numberOfDomains // 2
-        print("[i] {} domains are removed" .format(numberOfDomains))
-        remaining_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 OR type = 2 ")
-        print("[i] There are a total of {} domains remaining in your whitelist" .format(len(remaining_domains.fetchall())))
+        # we only removed domains we added so use total_domains
+        print("[i] {} domains are removed" .format(total_domains))
+        remaining_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 ") # only show exact whitelisted domains as we don't add/remove regex
+        print("[i] There are a total of {} domains remaining in your exact whitelist" .format(len(remaining_domains.fetchall())))
 
         cursor.close()
 

--- a/scripts/uninstall.py
+++ b/scripts/uninstall.py
@@ -122,14 +122,14 @@ if db_exists:
         total_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 AND comment LIKE '%qjz9zk%' ")
         
         totalDomains = len(total_domains.fetchall())
-        print("[i] There are a total of {} domains in your whitelist which are added by my script" .format(total_domains))
+        print("[i] There are a total of {} domains in your whitelist which are added by my script" .format(totalDomains))
         print('[i] Removing domains in the Gravity database')
         cursor.execute (" DELETE FROM domainlist WHERE type = 0 AND comment LIKE '%qjz9zk%' ")
 
         sqliteConnection.commit()
 
         # we only removed domains we added so use total_domains
-        print("[i] {} domains are removed" .format(total_domains))
+        print("[i] {} domains are removed" .format(totalDomains))
         remaining_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 ") # only show exact whitelisted domains as we don't add/remove regex
         print("[i] There are a total of {} domains remaining in your exact whitelist" .format(len(remaining_domains.fetchall())))
 

--- a/scripts/whitelist.py
+++ b/scripts/whitelist.py
@@ -133,7 +133,7 @@ if db_exists:
         # find only the domains we added
         number_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 AND comment LIKE '%qjz9zk%' ")
         
-        numberDomains = len(cursor.fetchall())
+        numberDomains = len(number_domains.fetchall())
         
         #print(f'[i] {numberOfDomains} domains are added to whitelist out of {len(whitelist_remote)}')
         print("[i] {} domains are added to whitelist out of {}" .format(numberOfDomains, len(whitelist_remote)))

--- a/scripts/whitelist.py
+++ b/scripts/whitelist.py
@@ -130,14 +130,14 @@ if db_exists:
 
         sqliteConnection.commit()
 
-        # total_changes is returning 2x the actual value. ¯\_(ツ)_/¯
-        # if I made a mistake, please create a PR
-        numberOfDomains = sqliteConnection.total_changes
-        if numberOfDomains > 1:
-            numberOfDomains = numberOfDomains // 2
+        # find only the domains we added
+        number_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 AND comment LIKE '%qjz9zk%' ")
+        
+        numberDomains = len(cursor.fetchall())
+        
         #print(f'[i] {numberOfDomains} domains are added to whitelist out of {len(whitelist_remote)}')
         print("[i] {} domains are added to whitelist out of {}" .format(numberOfDomains, len(whitelist_remote)))
-        total_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 OR type = 2 ")
+        total_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 ") # only show exact whitelisted domains as we don't add/remove regex
         #print(f'[i] There are a total of {len(total_domains.fetchall())} domains in your whitelist')
         print("[i] There are a total of {} domains in your whitelist" .format(len(total_domains.fetchall())))
         cursor.close()

--- a/scripts/whitelist.py
+++ b/scripts/whitelist.py
@@ -136,7 +136,7 @@ if db_exists:
         numberDomains = len(number_domains.fetchall())
         
         #print(f'[i] {numberOfDomains} domains are added to whitelist out of {len(whitelist_remote)}')
-        print("[i] {} domains are added to whitelist out of {}" .format(numberOfDomains, len(whitelist_remote)))
+        print("[i] {} domains are added to whitelist out of {}" .format(numberDomains, len(whitelist_remote)))
         total_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 ") # only show exact whitelisted domains as we don't add/remove regex
         #print(f'[i] There are a total of {len(total_domains.fetchall())} domains in your whitelist')
         print("[i] There are a total of {} domains in your whitelist" .format(len(total_domains.fetchall())))


### PR DESCRIPTION
https://github.com/anudeepND/whitelist/pull/158/files/e58bf0e986d6d1942b40c33f1458619c2941ac1a#diff-ae558a92912d7c9374a906e64b4b158eR133

and 

https://github.com/anudeepND/whitelist/pull/158/files/e58bf0e986d6d1942b40c33f1458619c2941ac1a#diff-6fea026f04d10fad806b3d3b71d7747aR129


IMO your only adding or removing and URL from the whitelist ```WHERE type = 0 AND comment LIKE '%qjz9zk%'``` so that's all we should check for. 

Also worth noting is the number you're wanting to get back from `total_changes` is the same as the number of domains added OR removed by the respective scripts.

```
 # find only the domains we added
        number_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 AND comment LIKE '%qjz9zk%' ")

        numberDomains = len(number_domains.fetchall())
```

new version can be tested from here

https://github.com/mwoolweaver/whitelist/tree/devel

`wget https://raw.githubusercontent.com/mwoolweaver/whitelist/devel/scripts/whitelist.py`