### PR TITLE
remove extra word

### DIFF
--- a/scripts/uninstall.py
+++ b/scripts/uninstall.py
@@ -166,7 +166,7 @@ if db_exists:
         # we only removed domains we added so use total_domains
         print("[i] {} domains are removed" .format(totalDomains))
         remaining_domains = cursor.execute(" SELECT * FROM domainlist WHERE type = 0 OR type = 2 ")
-        print("[i] There are a total of {} domains remaining in your exact whitelist" .format(len(remaining_domains.fetchall())))
+        print("[i] There are a total of {} domains remaining in your whitelist" .format(len(remaining_domains.fetchall())))
 
         cursor.close()
 


### PR DESCRIPTION
when I set to only check for only `type = 0` I added "exact" to the output in the uninstall script. This is not present in `whitelist.py`.

I am a dork. . .