### PR TITLE
Add python3 shebang

### DIFF
--- a/scripts/uninstall.py
+++ b/scripts/uninstall.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Project homepage: https://github.com/anudeepND/whitelist
 # Licence: https://github.com/anudeepND/whitelist/blob/master/LICENSE
 # Created by Anudeep

--- a/scripts/whitelist.py
+++ b/scripts/whitelist.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 # Project homepage: https://github.com/anudeepND/whitelist
 # Licence: https://github.com/anudeepND/whitelist/blob/master/LICENSE
 # Created by Anudeep


### PR DESCRIPTION
With a proper shebang you don't need `python3 whitelist.py` anymore.
A simple `./whitelist.py` is sufficient