### PR TITLE
Support using referral.sh with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,15 @@ git clone https://github.com/anudeepND/whitelist.git
 sudo python3 whitelist/scripts/whitelist.py
 ```
 
+```Shell
+git clone https://github.com/anudeepND/whitelist.git
+cd whitelist/scripts
+sudo ./referral.sh
+```
+
 #### For Docker installation (without Python3 support) or /etc/pihole on different directory
 
- You can pass two optional arguments to whitelist.py and uninstall.py:
+ You can pass two optional arguments to whitelist.py, uninstall.py, and referral.sh:
 
 ```Text
  -d or --dir to specify the Pi-hole etc directory (in normal install should be /etc/pihole)
@@ -162,6 +168,11 @@ git clone https://github.com/anudeepND/whitelist.git
 sudo python3 whitelist/scripts/whitelist.py --dir /home/docker/pihole/etc-pihole/ --docker
 ```
 
+```Shell
+git clone https://github.com/anudeepND/whitelist.git
+cd whitelist/scripts
+sudo ./referral.sh --dir /home/docker/pihole/etc-pihole/ --docker
+```
 __Note: You don't have to clone the repo every time you need to update whitelist file. Navigate to `whitelist/scripts` and run it again `sudo python3 whitelist.py__
 
 ## <ins>Uninstall</ins>

--- a/scripts/referral.sh
+++ b/scripts/referral.sh
@@ -7,6 +7,16 @@
 TICK="[\e[32m ✔ \e[0m]"
 PIHOLE_LOCATION="/etc/pihole"
 GRAVITY_UPDATE_COMMAND="pihole -w -q"
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -d|--dir) PIHOLE_LOCATION="$2"; shift ;;
+        -D|--docker) GRAVITY_UPDATE_COMMAND="docker exec pihole pihole -w -q" ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
 echo -e " \e[1m This file contains tracking and adserving domains. Run this script if you use specific service (like Slickdeals and Fatwallet etc.) that require certain adserving domains to be whitelisted. If you don't know what these services are, stay away from this list.  \e[0m"
 read -p "Do you want to continue (Y/N)? " -n 1 -r
 echo   
@@ -28,11 +38,11 @@ then
 	sleep 0.5
 	echo -e " ${TICK} \e[32m Removing duplicates... \e[0m"
 
-	mv "${PIHOLE_LOCATION}"/whitelist.txt /etc/pihole/whitelist.txt.old && cat "${PIHOLE_LOCATION}"/whitelist.txt.old | sort | uniq >> "${PIHOLE_LOCATION}"/whitelist.txt
+	mv "${PIHOLE_LOCATION}"/whitelist.txt "${PIHOLE_LOCATION}"/whitelist.txt.old && cat "${PIHOLE_LOCATION}"/whitelist.txt.old | sort | uniq >> "${PIHOLE_LOCATION}"/whitelist.txt
 
 	wait
 	echo -e " [...] \e[32m Pi-hole gravity rebuilding lists. This may take a while \e[0m"
-	${GRAVITY_UPDATE_COMMAND} $(cat /etc/pihole/whitelist.txt | xargs) > /dev/null
+	${GRAVITY_UPDATE_COMMAND} $(cat "${PIHOLE_LOCATION}"/whitelist.txt | xargs) > /dev/null
 	wait
 	echo -e " ${TICK} \e[32m Pi-hole's gravity updated \e[0m"
 	echo -e " ${TICK} \e[32m Done! \e[0m"


### PR DESCRIPTION
Following on the work done in https://github.com/anudeepND/whitelist/pull/162, this adds the same optional arguments (`-d` `--dir` & `-D` `--docker`) to referral.sh in order to allow using the script while running Pi-Hole in Docker.