### PR TITLE
Add formspark.io domains

### DIFF
--- a/domains/whitelist.txt
+++ b/domains/whitelist.txt
@@ -6,6 +6,7 @@ akamaitechnologies.com
 akamaized.net
 amazonaws.com
 android.clients.google.com
+api.formspark.io
 api.ipify.org
 api.rlje.net
 app-api.ted.com
@@ -60,6 +61,7 @@ ecn.dev.virtualearth.net
 edge.api.brightcove.com
 eds.xboxlive.com
 fonts.gstatic.com
+formspark.io
 forums.sonarr.tv
 g.live.com
 geo-prod.do.dsp.mp.microsoft.com
@@ -144,6 +146,7 @@ spclient.wg.spotify.com
 ssl.p.jwpcdn.com
 staging.plex.tv
 status.plex.tv
+submit-form.com
 t.co
 t0.ssl.ak.dynamic.tiles.virtualearth.net
 t0.ssl.ak.tiles.virtualearth.net


### PR DESCRIPTION
Bjorn from Formspark here

I would like to request the whitelisting of the following domains

- api.formspark.io
- formspark.io
- submit-form.com

These domains are used by https://formspark.io/, a form to email service.

While occasionally our service is used by malicious actors, this only represents a minor percentage of our user base.

The blacklisting of these domains severely affects certain users

Thanks!